### PR TITLE
Fix valued_moves

### DIFF
--- a/shipment.py
+++ b/shipment.py
@@ -59,10 +59,11 @@ class ShipmentValuedMixin(TaxableMixin):
         origins = Move._get_origin()
         keep_origin = True if 'stock.move' in origins else False
         move_field = MOVES.get(self.__name__)
-        if (keep_origin and self.__name__ == 'stock.shipment.out'):
-            moves = getattr(self, 'inventory_moves', [])
-            if moves:
-                return moves
+        if (
+            (keep_origin and self.__name__ == 'stock.shipment.out')
+            and (moves := getattr(self, 'outgoing_moves', []))
+        ):
+            return moves
         return getattr(self, move_field, [])
 
     @property


### PR DESCRIPTION
The amounts aren't correctly calculated, due the calc_amounts method calls the valued_moves, and they don't have any amount. This is because they are taking their value from the internal moves (the inventory_moves) instead of from the outgoing_moves, which ones do have amounts.